### PR TITLE
Json result

### DIFF
--- a/src/FluentAssertions.AspNetCore.Mvc/ActionResultAssertions.cs
+++ b/src/FluentAssertions.AspNetCore.Mvc/ActionResultAssertions.cs
@@ -86,6 +86,21 @@ namespace FluentAssertions.AspNetCore.Mvc
             return Subject as EmptyResult;
         }
 
+        public JsonResultAssertions BeJsonResult()
+        {
+            return BeJsonResult(string.Empty, null);
+        }
+
+        public JsonResultAssertions BeJsonResult(string reason, params object[] reasonArgs)
+        {
+            Execute.Assertion
+                .BecauseOf(reason, reasonArgs)
+                .ForCondition(Subject is JsonResult)
+                .FailWith(Constants.CommonFailMessage, typeof(JsonResult).Name, Subject.GetType().Name);
+
+            return new JsonResultAssertions(Subject as JsonResult);
+        }
+
         /// <summary>
         /// Asserts that the subject is a <see cref="RedirectToRouteResult"/>.
         /// </summary>

--- a/src/FluentAssertions.AspNetCore.Mvc/ActionResultAssertions.cs
+++ b/src/FluentAssertions.AspNetCore.Mvc/ActionResultAssertions.cs
@@ -86,11 +86,24 @@ namespace FluentAssertions.AspNetCore.Mvc
             return Subject as EmptyResult;
         }
 
+        /// <summary>
+        /// Asserts that the subject is an <see cref="JsonResult"/>.
+        /// </summary>
         public JsonResultAssertions BeJsonResult()
         {
             return BeJsonResult(string.Empty, null);
         }
 
+        /// <summary>
+        /// Asserts that the subject is an <see cref="JsonResult"/>.
+        /// </summary>
+        /// <param name="reason">
+        /// A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+        /// is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="reasonArgs">
+        /// Zero or more objects to format using the placeholders in <see cref="reason" />.
+        /// </param>
         public JsonResultAssertions BeJsonResult(string reason, params object[] reasonArgs)
         {
             Execute.Assertion

--- a/src/FluentAssertions.AspNetCore.Mvc/FailureMessages.Designer.cs
+++ b/src/FluentAssertions.AspNetCore.Mvc/FailureMessages.Designer.cs
@@ -19,7 +19,7 @@ namespace FluentAssertions.AspNetCore.Mvc {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class FailureMessages {
@@ -66,6 +66,24 @@ namespace FluentAssertions.AspNetCore.Mvc {
         internal static string CommonFailMessage {
             get {
                 return ResourceManager.GetString("CommonFailMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Expected {0} to be of type {1}, but no {0} was supplied..
+        /// </summary>
+        internal static string CommonNullWasSuppliedFailMessage {
+            get {
+                return ResourceManager.GetString("CommonNullWasSuppliedFailMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Expected {0} to be of type &apos;{1}&apos; but was &apos;{2}&apos;.
+        /// </summary>
+        internal static string CommonTypeFailMessage {
+            get {
+                return ResourceManager.GetString("CommonTypeFailMessage", resourceCulture);
             }
         }
         
@@ -129,15 +147,6 @@ namespace FluentAssertions.AspNetCore.Mvc {
         internal static string ViewResult_MasterName {
             get {
                 return ResourceManager.GetString("ViewResult_MasterName", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Expected Model to be of type {0}, but no Model was supplied..
-        /// </summary>
-        internal static string ViewResultBase_NullModel {
-            get {
-                return ResourceManager.GetString("ViewResultBase_NullModel", resourceCulture);
             }
         }
         

--- a/src/FluentAssertions.AspNetCore.Mvc/FailureMessages.resx
+++ b/src/FluentAssertions.AspNetCore.Mvc/FailureMessages.resx
@@ -120,6 +120,12 @@
   <data name="CommonFailMessage" xml:space="preserve">
     <value>Expected {0} to be '{1}' but found '{2}'</value>
   </data>
+  <data name="CommonNullWasSuppliedFailMessage" xml:space="preserve">
+    <value>Expected {0} to be of type {1}, but no {0} was supplied.</value>
+  </data>
+  <data name="CommonTypeFailMessage" xml:space="preserve">
+    <value>Expected {0} to be of type '{1}' but was '{2}'</value>
+  </data>
   <data name="RedirectToActionResult_RouteValues_ContainsKey" xml:space="preserve">
     <value>RedirectToActionResult.RouteValues does not contain key {0}.</value>
   </data>
@@ -137,9 +143,6 @@
   </data>
   <data name="RouteData_Values_HaveValue" xml:space="preserve">
     <value>Expected RouteData.Values[{0}] to have value {1}, but found {2}.</value>
-  </data>
-  <data name="ViewResultBase_NullModel" xml:space="preserve">
-    <value>Expected Model to be of type {0}, but no Model was supplied.</value>
   </data>
   <data name="ViewResultBase_ViewData_ContainsKey" xml:space="preserve">
     <value>ViewData does not contain key of {0}.</value>

--- a/src/FluentAssertions.AspNetCore.Mvc/FluentAssertions.AspNetCore.Mvc.csproj
+++ b/src/FluentAssertions.AspNetCore.Mvc/FluentAssertions.AspNetCore.Mvc.csproj
@@ -29,4 +29,19 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.0.0" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Update="FailureMessages.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>FailureMessages.resx</DependentUpon>
+    </Compile>
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Update="FailureMessages.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>FailureMessages.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+  </ItemGroup>
+
 </Project>

--- a/src/FluentAssertions.AspNetCore.Mvc/JsonResultAssertions.cs
+++ b/src/FluentAssertions.AspNetCore.Mvc/JsonResultAssertions.cs
@@ -1,6 +1,7 @@
 ﻿using FluentAssertions.Execution;
 using FluentAssertions.Primitives;
 using Microsoft.AspNetCore.Mvc;
+using Newtonsoft.Json;
 using System;
 using System.Diagnostics;
 
@@ -26,6 +27,11 @@ namespace FluentAssertions.AspNetCore.Mvc
         #endregion
 
         #region Public Properties
+
+        /// <summary>
+        ///     The serializer settings of the JsonResult.
+        /// </summary>
+        public JsonSerializerSettings SerializerSettings => JsonResultSubject.SerializerSettings;
 
         /// <summary>
         ///     The value on the JsonResult

--- a/src/FluentAssertions.AspNetCore.Mvc/JsonResultAssertions.cs
+++ b/src/FluentAssertions.AspNetCore.Mvc/JsonResultAssertions.cs
@@ -66,6 +66,24 @@ namespace FluentAssertions.AspNetCore.Mvc
             return this;
         }
 
+        /// <summary>
+        ///     Asserts the value is of the expected type.
+        /// </summary>
+        /// <typeparam name="TValue">The expected type.</typeparam>
+        /// <returns>The typed value.</returns>
+        public TValue ValueAs<TValue>()
+        {
+            var value = JsonResultSubject.Value;
+
+            if (value == null)
+                Execute.Assertion.FailWith(FailureMessages.CommonNullWasSuppliedFailMessage, "Value", typeof(TValue).Name);
+
+            Execute.Assertion
+                .ForCondition(value is TValue)
+                .FailWith(FailureMessages.CommonTypeFailMessage, "Value", typeof(TValue).Name, value.GetType().Name);
+
+            return (TValue)value;
+        }
         #endregion
     }
 }

--- a/src/FluentAssertions.AspNetCore.Mvc/JsonResultAssertions.cs
+++ b/src/FluentAssertions.AspNetCore.Mvc/JsonResultAssertions.cs
@@ -1,0 +1,45 @@
+﻿using FluentAssertions.Execution;
+using FluentAssertions.Primitives;
+using Microsoft.AspNetCore.Mvc;
+using System;
+
+namespace FluentAssertions.AspNetCore.Mvc
+{
+    public class JsonResultAssertions : ObjectAssertions
+    {
+        #region Public Constructors
+
+        public JsonResultAssertions(JsonResult subject) : base(subject)
+        {
+
+        }
+
+        #endregion
+
+        #region Public Properties
+
+        #endregion
+
+        #region Private Properties
+
+        private JsonResult JsonResultSubject => (JsonResult)Subject;
+
+        #endregion Private Properties
+
+        #region Public Methods
+
+        public JsonResultAssertions WithValue(object expectedValue, string reason = "",
+            params object[] reasonArgs)
+        {
+            var actualValue = JsonResultSubject.Value;
+
+            Execute.Assertion
+                .ForCondition(Equals(expectedValue, actualValue))
+                .BecauseOf(reason, reasonArgs)
+                .FailWith(FailureMessages.CommonFailMessage, "JsonResult.Value", expectedValue, actualValue);
+            return this;
+        }
+
+        #endregion
+    }
+}

--- a/src/FluentAssertions.AspNetCore.Mvc/JsonResultAssertions.cs
+++ b/src/FluentAssertions.AspNetCore.Mvc/JsonResultAssertions.cs
@@ -72,6 +72,29 @@ namespace FluentAssertions.AspNetCore.Mvc
         }
 
         /// <summary>
+        ///     Asserts that the status code is the expected status code.
+        /// </summary>
+        /// <param name="statusCode">The expected status code.</param>
+        /// <param name="reason">
+        ///     A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+        ///     is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="reasonArgs">
+        ///     Zero or more objects to format using the placeholders in <see cref="reason" />.
+        /// </param>
+        public JsonResultAssertions WithStatusCode(int? expectedStatusCode, string reason = "",
+            params object[] reasonArgs)
+        {
+            var actualStatusCode = JsonResultSubject.StatusCode;
+
+            Execute.Assertion
+                .ForCondition(expectedStatusCode == actualStatusCode)
+                .BecauseOf(reason, reasonArgs)
+                .FailWith(FailureMessages.CommonFailMessage, "JsonResult.StatusCode", expectedStatusCode, actualStatusCode);
+            return this;
+        }
+
+        /// <summary>
         ///     Asserts the value is of the expected type.
         /// </summary>
         /// <typeparam name="TValue">The expected type.</typeparam>

--- a/src/FluentAssertions.AspNetCore.Mvc/JsonResultAssertions.cs
+++ b/src/FluentAssertions.AspNetCore.Mvc/JsonResultAssertions.cs
@@ -43,9 +43,9 @@ namespace FluentAssertions.AspNetCore.Mvc
         #region Public Methods
 
         /// <summary>
-        ///     Asserts that the value is the expected value using Equals.
+        ///     Asserts that the content type is the expected content type.
         /// </summary>
-        /// <param name="expectedValue">The expected value.</param>
+        /// <param name="expectedContentType">The expected content type.</param>
         /// <param name="reason">
         ///     A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
         ///     is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
@@ -53,16 +53,15 @@ namespace FluentAssertions.AspNetCore.Mvc
         /// <param name="reasonArgs">
         ///     Zero or more objects to format using the placeholders in <see cref="reason" />.
         /// </param>
-        /// <returns></returns>
-        public JsonResultAssertions WithValue(object expectedValue, string reason = "",
+        public JsonResultAssertions WithContentType(string expectedContentType, string reason = "",
             params object[] reasonArgs)
         {
-            var actualValue = JsonResultSubject.Value;
+            var actualContentType = JsonResultSubject.ContentType;
 
             Execute.Assertion
-                .ForCondition(Equals(expectedValue, actualValue))
+                .ForCondition(string.Equals(expectedContentType, actualContentType, StringComparison.OrdinalIgnoreCase))
                 .BecauseOf(reason, reasonArgs)
-                .FailWith(FailureMessages.CommonFailMessage, "JsonResult.Value", expectedValue, actualValue);
+                .FailWith(FailureMessages.CommonFailMessage, "JsonResult.ContentType", expectedContentType, actualContentType);
             return this;
         }
 

--- a/src/FluentAssertions.AspNetCore.Mvc/JsonResultAssertions.cs
+++ b/src/FluentAssertions.AspNetCore.Mvc/JsonResultAssertions.cs
@@ -2,13 +2,22 @@
 using FluentAssertions.Primitives;
 using Microsoft.AspNetCore.Mvc;
 using System;
+using System.Diagnostics;
 
 namespace FluentAssertions.AspNetCore.Mvc
 {
+    /// <summary>
+    ///     Contains a number of methods to assert that a <see cref="JsonResult" /> is in the expected state.
+    /// </summary>
+    [DebuggerNonUserCode]
     public class JsonResultAssertions : ObjectAssertions
     {
         #region Public Constructors
 
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="T:JsonResultAssertions" /> class.
+        /// </summary>
+        /// <param name="subject">The object to test assertion on</param>
         public JsonResultAssertions(JsonResult subject) : base(subject)
         {
 
@@ -17,6 +26,11 @@ namespace FluentAssertions.AspNetCore.Mvc
         #endregion
 
         #region Public Properties
+
+        /// <summary>
+        ///     The value on the JsonResult
+        /// </summary>
+        public object Value => JsonResultSubject.Value;
 
         #endregion
 
@@ -28,6 +42,18 @@ namespace FluentAssertions.AspNetCore.Mvc
 
         #region Public Methods
 
+        /// <summary>
+        ///     Asserts that the value is the expected value using Equals.
+        /// </summary>
+        /// <param name="expectedValue">The expected value.</param>
+        /// <param name="reason">
+        ///     A formatted phrase as is supported by <see cref="string.Format(string,object[])" /> explaining why the assertion
+        ///     is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.
+        /// </param>
+        /// <param name="reasonArgs">
+        ///     Zero or more objects to format using the placeholders in <see cref="reason" />.
+        /// </param>
+        /// <returns></returns>
         public JsonResultAssertions WithValue(object expectedValue, string reason = "",
             params object[] reasonArgs)
         {

--- a/src/FluentAssertions.AspNetCore.Mvc/PartialViewResultAssertions.cs
+++ b/src/FluentAssertions.AspNetCore.Mvc/PartialViewResultAssertions.cs
@@ -15,7 +15,7 @@ namespace FluentAssertions.AspNetCore.Mvc
         {
         }
 
-        private PartialViewResult PartialViewResultSubject => (PartialViewResult) Subject;
+        private PartialViewResult PartialViewResultSubject => (PartialViewResult)Subject;
 
         /// <summary>
         ///     The model.
@@ -114,13 +114,13 @@ namespace FluentAssertions.AspNetCore.Mvc
             var model = PartialViewResultSubject.ViewData?.Model;
 
             if (model == null)
-                Execute.Assertion.FailWith(FailureMessages.ViewResultBase_NullModel, typeof(TModel).Name);
+                Execute.Assertion.FailWith(FailureMessages.CommonNullWasSuppliedFailMessage, "Model", typeof(TModel).Name);
 
             Execute.Assertion
                 .ForCondition(model is TModel)
-                .FailWith("Expected Model to be of type '{0}' but was '{1}'", typeof(TModel).Name, model.GetType().Name);
+                .FailWith(FailureMessages.CommonTypeFailMessage, "Model", typeof(TModel).Name, model.GetType().Name);
 
-            return (TModel) model;
+            return (TModel)model;
         }
 
         /// <summary>

--- a/src/FluentAssertions.AspNetCore.Mvc/ViewResultAssertions.cs
+++ b/src/FluentAssertions.AspNetCore.Mvc/ViewResultAssertions.cs
@@ -133,11 +133,11 @@ namespace FluentAssertions.AspNetCore.Mvc
             var model = ViewResultSubject.Model;
 
             if (model == null)
-                Execute.Assertion.FailWith(FailureMessages.ViewResultBase_NullModel, typeof(TModel).Name);
+                Execute.Assertion.FailWith(FailureMessages.CommonNullWasSuppliedFailMessage, "Model", typeof(TModel).Name);
 
             Execute.Assertion
                 .ForCondition(model is TModel)
-                .FailWith("Expected Model to be of type '{0}' but was '{1}'", typeof(TModel).Name, model.GetType().Name);
+                .FailWith(FailureMessages.CommonTypeFailMessage, "Model", typeof(TModel).Name, model.GetType().Name);
 
             return (TModel)model;
         }

--- a/tests/FluentAssertions.AspNetCore.Mvc.Tests/ActionResultAssertions_Tests.cs
+++ b/tests/FluentAssertions.AspNetCore.Mvc.Tests/ActionResultAssertions_Tests.cs
@@ -43,6 +43,23 @@ namespace FluentAssertions.AspNetCore.Mvc.Tests
         }
 
         [Fact]
+        public void BeJson_GivenJson_ShouldPass()
+        {
+            ActionResult result = new JsonResult(new object());
+            result.Should()
+                .BeJsonResult();
+        }
+
+        [Fact]
+        public void BeJson_GivenNotJson_ShouldFail()
+        {
+            ActionResult result = new ViewResult();
+            Action a = () => result.Should().BeJsonResult();
+            a.Should().Throw<Exception>()
+                .WithMessage("Expected ActionResult to be \"JsonResult\", but found \"ViewResult\"");
+        }
+
+        [Fact]
         public void BeRedirectToRoute_GivenRedirectToRoute_ShouldPass()
         {
             ActionResult result = new RedirectToRouteResult(new RouteValueDictionary());

--- a/tests/FluentAssertions.AspNetCore.Mvc.Tests/JsonResultAssertions_Tests.cs
+++ b/tests/FluentAssertions.AspNetCore.Mvc.Tests/JsonResultAssertions_Tests.cs
@@ -8,21 +8,28 @@ namespace FluentAssertions.AspNetCore.Mvc.Tests
     public class JsonResultAssertions_Tests
     {
         [Fact]
-        public void WithValue_GivenValue_ShouldPass()
+        public void WithContentType_GivenValue_ShouldPass()
         {
-            ActionResult result = new JsonResult("value");
-            result.Should().BeJsonResult().WithValue("value");
+            ActionResult result = new JsonResult("value")
+            {
+                ContentType = "text/plain"
+            };
+
+            result.Should().BeJsonResult().WithContentType("text/plain");
         }
 
         [Fact]
-        public void WithValue_GivenUnexpected_ShouldFail()
+        public void WithContentType_GivenUnexpected_ShouldFail()
         {
-            var actualValue = "xyz";
-            var expectedValue = "value";
-            ActionResult result = new JsonResult(actualValue);
-            var failureMessage = FailureMessageHelper.Format(FailureMessages.CommonFailMessage, "JsonResult.Value", expectedValue, actualValue);
+            var actualValue = "text/css";
+            var expectedValue = "text/plain";
+            ActionResult result = new JsonResult("value")
+            {
+                ContentType = actualValue
+            };
+            var failureMessage = FailureMessageHelper.Format(FailureMessages.CommonFailMessage, "JsonResult.ContentType", expectedValue, actualValue);
 
-            Action a = () => result.Should().BeJsonResult().WithValue(expectedValue);
+            Action a = () => result.Should().BeJsonResult().WithContentType(expectedValue);
 
             a.Should().Throw<Exception>()
                 .WithMessage(failureMessage);

--- a/tests/FluentAssertions.AspNetCore.Mvc.Tests/JsonResultAssertions_Tests.cs
+++ b/tests/FluentAssertions.AspNetCore.Mvc.Tests/JsonResultAssertions_Tests.cs
@@ -1,5 +1,6 @@
 ﻿using FluentAssertions.Mvc.Tests.Helpers;
 using Microsoft.AspNetCore.Mvc;
+using Newtonsoft.Json;
 using System;
 using Xunit;
 
@@ -90,5 +91,13 @@ namespace FluentAssertions.AspNetCore.Mvc.Tests
                 .WithMessage(failureMessage);
         }
 
+        [Fact]
+        public void SerializerSettings_GivenExpectedValue_ShouldPass()
+        {
+            var expectedValue = new JsonSerializerSettings();
+            var result = new JsonResult("value", expectedValue);
+
+            result.Should().BeJsonResult().SerializerSettings.Should().BeSameAs(expectedValue);
+        }
     }
 }

--- a/tests/FluentAssertions.AspNetCore.Mvc.Tests/JsonResultAssertions_Tests.cs
+++ b/tests/FluentAssertions.AspNetCore.Mvc.Tests/JsonResultAssertions_Tests.cs
@@ -1,0 +1,31 @@
+﻿using FluentAssertions.Mvc.Tests.Helpers;
+using Microsoft.AspNetCore.Mvc;
+using System;
+using Xunit;
+
+namespace FluentAssertions.AspNetCore.Mvc.Tests
+{
+    public class JsonResultAssertions_Tests
+    {
+        [Fact]
+        public void WithValue_GivenValue_ShouldPass()
+        {
+            ActionResult result = new JsonResult("value");
+            result.Should().BeJsonResult().WithValue("value");
+        }
+
+        [Fact]
+        public void WithValue_GivenUnexpected_ShouldFail()
+        {
+            var actualValue = "xyz";
+            var expectedValue = "value";
+            ActionResult result = new JsonResult(actualValue);
+            var failureMessage = FailureMessageHelper.Format(FailureMessages.CommonFailMessage, "JsonResult.Value", expectedValue, actualValue);
+
+            Action a = () => result.Should().BeJsonResult().WithValue(expectedValue);
+
+            a.Should().Throw<Exception>()
+                .WithMessage(failureMessage);
+        }
+    }
+}

--- a/tests/FluentAssertions.AspNetCore.Mvc.Tests/JsonResultAssertions_Tests.cs
+++ b/tests/FluentAssertions.AspNetCore.Mvc.Tests/JsonResultAssertions_Tests.cs
@@ -27,5 +27,61 @@ namespace FluentAssertions.AspNetCore.Mvc.Tests
             a.Should().Throw<Exception>()
                 .WithMessage(failureMessage);
         }
+
+        [Fact]
+        public void Value_GivenExpectedValue_ShouldPass()
+        {
+            var result = new TestController().JsonSimpleValue();
+
+            result.Should().BeJsonResult().Value.Should().Be("hello");
+        }
+
+        [Fact]
+        public void Json_GivenUnexpectedValue_ShouldFail()
+        {
+            var result = new TestController().JsonSimpleValue();
+
+            Action a = () => result.Should().BeJsonResult().Value.Should().Be("xyx");
+            a.Should().Throw<Exception>();
+        }
+
+        [Fact]
+        public void ValueAs_GivenExpectedValue_ShouldPass()
+        {
+            var result = new TestController().JsonSimpleValue();
+
+            result.Should().BeJsonResult().ValueAs<string>().Should().Be("hello");
+        }
+
+        [Fact]
+        public void ValueAs_GivenUnexpectedValue_ShouldFail()
+        {
+            var result = new TestController().JsonSimpleValue();
+
+            Action a = () => result.Should().BeJsonResult().ValueAs<string>().Should().Be("xyx");
+            a.Should().Throw<Exception>();
+        }
+
+        [Fact]
+        public void ValueAs_GivenWrongType_ShouldFail()
+        {
+            var result = new TestController().JsonSimpleValue();
+
+            Action a = () => result.Should().BeJsonResult().ValueAs<int>().Should().Be(2);
+            a.Should().Throw<Exception>();
+        }
+
+        [Fact]
+        public void ValueAs_Null_ShouldFail()
+        {
+            ActionResult result = new JsonResult(null);
+            string failureMessage = FailureMessageHelper.Format(FailureMessages.CommonNullWasSuppliedFailMessage, "Value", typeof(Object).Name);
+
+            Action a = () => result.Should().BeJsonResult().ValueAs<Object>();
+
+            a.Should().Throw<Exception>()
+                .WithMessage(failureMessage);
+        }
+
     }
 }

--- a/tests/FluentAssertions.AspNetCore.Mvc.Tests/JsonResultAssertions_Tests.cs
+++ b/tests/FluentAssertions.AspNetCore.Mvc.Tests/JsonResultAssertions_Tests.cs
@@ -37,6 +37,34 @@ namespace FluentAssertions.AspNetCore.Mvc.Tests
         }
 
         [Fact]
+        public void WithStatusCode_GivenValue_ShouldPass()
+        {
+            ActionResult result = new JsonResult("value")
+            {
+                StatusCode = 200
+            };
+
+            result.Should().BeJsonResult().WithStatusCode(200);
+        }
+
+        [Fact]
+        public void WithStatusCode_GivenUnexpected_ShouldFail()
+        {
+            var actualStatusCode = 401;
+            var expectedStatusCode = 200;
+            ActionResult result = new JsonResult("value")
+            {
+                StatusCode = actualStatusCode
+            };
+            var failureMessage = string.Format(FailureMessages.CommonFailMessage, "\"JsonResult.StatusCode\"", expectedStatusCode, actualStatusCode);
+
+            Action a = () => result.Should().BeJsonResult().WithStatusCode(expectedStatusCode);
+
+            a.Should().Throw<Exception>()
+                .WithMessage(failureMessage);
+        }
+
+        [Fact]
         public void Value_GivenExpectedValue_ShouldPass()
         {
             var result = new TestController().JsonSimpleValue();
@@ -45,7 +73,7 @@ namespace FluentAssertions.AspNetCore.Mvc.Tests
         }
 
         [Fact]
-        public void Json_GivenUnexpectedValue_ShouldFail()
+        public void Value_GivenUnexpectedValue_ShouldFail()
         {
             var result = new TestController().JsonSimpleValue();
 

--- a/tests/FluentAssertions.AspNetCore.Mvc.Tests/PartialViewResultAssertions_Tests.cs
+++ b/tests/FluentAssertions.AspNetCore.Mvc.Tests/PartialViewResultAssertions_Tests.cs
@@ -66,7 +66,7 @@ namespace FluentAssertions.AspNetCore.Mvc.Tests
         public void ModelAs_Null_ShouldFail()
         {
             ActionResult result = new PartialViewResult();
-            string failureMessage = FailureMessageHelper.Format(FailureMessages.ViewResultBase_NullModel, typeof(Object).Name);
+            string failureMessage = FailureMessageHelper.Format(FailureMessages.CommonNullWasSuppliedFailMessage, "Model", typeof(Object).Name);
 
             Action a = () =>
             {

--- a/tests/FluentAssertions.AspNetCore.Mvc.Tests/TestController.cs
+++ b/tests/FluentAssertions.AspNetCore.Mvc.Tests/TestController.cs
@@ -57,5 +57,10 @@ namespace FluentAssertions.AspNetCore.Mvc.Tests
             ViewData["key2"] = "value2";
             return View();
         }
+
+        public JsonResult JsonSimpleValue()
+        {
+            return Json(data: "hello");
+        }
     }
 }

--- a/tests/FluentAssertions.AspNetCore.Mvc.Tests/ViewResultAssertions_Tests.cs
+++ b/tests/FluentAssertions.AspNetCore.Mvc.Tests/ViewResultAssertions_Tests.cs
@@ -175,7 +175,7 @@ namespace FluentAssertions.AspNetCore.Mvc.Tests
         public void ModelAs_Null_ShouldFail()
         {
             ActionResult result = new ViewResult();
-            string failureMessage = FailureMessageHelper.Format(FailureMessages.ViewResultBase_NullModel, typeof(Object).Name);
+            string failureMessage = FailureMessageHelper.Format(FailureMessages.CommonNullWasSuppliedFailMessage, "Model", typeof(Object).Name);
 
             Action a = () => result.Should().BeViewResult().ModelAs<Object>();
 


### PR DESCRIPTION
Hy Kevin,

I added JsonResult assertions to the project. I thought it would be useful. Please review if this is fine.
This consist of the followings:
result.Should().BeJsonResult()
result.Should().BeJsonResult().WithContentType("content type");
result.Should().BeJsonResult().WithStatusCode(200);
result.Should().BeJsonResult().Value (For the JsonResult.Value)
result.Should().BeJsonResult().ValueAs<Type>() (Type checking and casting like in the ViewResult)
result.Should().BeJsonResult().SerializerSettings (For the JsonResult.SerializerSettings)

I am also interested doing further works on this project.