### PR TITLE
Add support for FluentAssertions v6.0.

### DIFF
--- a/src/FluentAssertions.AspNetCore.Mvc.Ref/FluentAssertions.AspNetCore.Mvc.Ref.csproj
+++ b/src/FluentAssertions.AspNetCore.Mvc.Ref/FluentAssertions.AspNetCore.Mvc.Ref.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="5.0.0" />
+    <PackageReference Include="FluentAssertions" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">

--- a/src/FluentAssertions.AspNetCore.Mvc/ActionResultAssertions.cs
+++ b/src/FluentAssertions.AspNetCore.Mvc/ActionResultAssertions.cs
@@ -18,7 +18,6 @@ namespace FluentAssertions.AspNetCore.Mvc
         /// </summary>
         public ActionResultAssertions(IActionResult subject) : base(subject)
         {
-            Subject = subject;
         }
 
         #endregion Public Constructors

--- a/src/FluentAssertions.AspNetCore.Mvc/ActionResultAssertionsOfTValue.cs
+++ b/src/FluentAssertions.AspNetCore.Mvc/ActionResultAssertionsOfTValue.cs
@@ -17,9 +17,8 @@ namespace FluentAssertions.AspNetCore.Mvc
         /// <summary>
         /// Initializes a new instance of the <see cref="ActionResultAssertions{TValue}" /> class.
         /// </summary>
-        public ActionResultAssertions(ActionResult<TValue> subject)
+        public ActionResultAssertions(ActionResult<TValue> subject) : base(subject)
         {
-            Subject = subject;
         }
 
         #endregion Public Constructors

--- a/src/FluentAssertions.AspNetCore.Mvc/AssertionHelpers.cs
+++ b/src/FluentAssertions.AspNetCore.Mvc/AssertionHelpers.cs
@@ -30,7 +30,7 @@ namespace FluentAssertions.AspNetCore.Mvc
                 {
                     Execute.Assertion
                         .BecauseOf(reason, reasonArgs)
-                        .ForCondition(actual.IsSameOrEqualTo(expectedValue))
+                        .ForCondition(Equals(actual, expectedValue))
                         .FailWith("Expected {context} to contain value {0} at key {1}{reason} but found {2}.", expectedValue, key, actual);
                 }
                 else

--- a/src/FluentAssertions.AspNetCore.Mvc/ConvertToActionResultAssertions.cs
+++ b/src/FluentAssertions.AspNetCore.Mvc/ConvertToActionResultAssertions.cs
@@ -13,9 +13,8 @@ namespace FluentAssertions.AspNetCore.Mvc
         /// <summary>
         /// Initializes a new instance of the <see cref="ConvertToActionResultAssertions" /> class.
         /// </summary>
-        public ConvertToActionResultAssertions(IConvertToActionResult subject)
+        public ConvertToActionResultAssertions(IConvertToActionResult subject) : base(subject)
         {
-            Subject = subject;
         }
 
         /// <inheritdoc />

--- a/src/FluentAssertions.AspNetCore.Mvc/FluentAssertions.AspNetCore.Mvc.csproj
+++ b/src/FluentAssertions.AspNetCore.Mvc/FluentAssertions.AspNetCore.Mvc.csproj
@@ -24,7 +24,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="5.0.0" />
+    <PackageReference Include="FluentAssertions" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">

--- a/src/FluentAssertions.AspNetCore.Mvc/ObjectResultAssertionsBase.cs
+++ b/src/FluentAssertions.AspNetCore.Mvc/ObjectResultAssertionsBase.cs
@@ -184,7 +184,7 @@ namespace FluentAssertions.AspNetCore.Mvc
 
             Execute.Assertion
                 .BecauseOf(reason, reasonArgs)
-                .ForCondition(actualValue.IsSameOrEqualTo(expectedValue))
+                .ForCondition(Equals(actualValue, expectedValue))
                 .WithDefaultIdentifier(Identifier + ".Value")
                 .FailWith(FailureMessages.CommonFailMessage, expectedValue, actualValue);
 

--- a/src/FluentAssertions.AspNetCore.Mvc/RedirectToRouteAssertions.cs
+++ b/src/FluentAssertions.AspNetCore.Mvc/RedirectToRouteAssertions.cs
@@ -17,9 +17,8 @@ namespace FluentAssertions.AspNetCore.Mvc
         /// <summary>
         /// Initializes a new instance of the <see cref="ContentResultAssertions" /> class.
         /// </summary>
-        public RedirectToRouteAssertions(RedirectToRouteResult subject)
+        public RedirectToRouteAssertions(RedirectToRouteResult subject) : base(subject)
         {
-            Subject = subject;
         }
 
         #endregion Public Constructors

--- a/src/FluentAssertions.AspNetCore.Mvc/RouteDataAssertions.cs
+++ b/src/FluentAssertions.AspNetCore.Mvc/RouteDataAssertions.cs
@@ -17,7 +17,6 @@ namespace FluentAssertions.AspNetCore.Mvc
         public RouteDataAssertions(RouteData subject)
             : base(subject)
         {
-            Subject = subject;
         }
 
         /// <summary>

--- a/tests/FluentAssertions.AspNetCore.Mvc.Tests/FluentAssertions.AspNetCore.Mvc.Tests.csproj
+++ b/tests/FluentAssertions.AspNetCore.Mvc.Tests/FluentAssertions.AspNetCore.Mvc.Tests.csproj
@@ -7,7 +7,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="5.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.1" />
     <PackageReference Include="Moq" Version="4.8.2" />
     <PackageReference Include="xunit" Version="2.3.1" />

--- a/tests/FluentAssertions.AspNetCore.Mvc.Tests/Helpers/FailureMessageHelper.cs
+++ b/tests/FluentAssertions.AspNetCore.Mvc.Tests/Helpers/FailureMessageHelper.cs
@@ -97,24 +97,24 @@ namespace FluentAssertions.Mvc.Tests.Helpers
 
 Microsoft.AspNetCore.Authentication.AuthenticationProperties
 {
-   AllowRefresh = <null>
-   ExpiresUtc = <null>
-   IsPersistent = False
-   IssuedUtc = <null>
-   Items = {empty}
-   Parameters = {empty}
-   RedirectUri = <null>
+    AllowRefresh = <null>, 
+    ExpiresUtc = <null>, 
+    IsPersistent = False, 
+    IssuedUtc = <null>, 
+    Items = {empty}, 
+    Parameters = {empty}, 
+    RedirectUri = <null>
 } because it is 10 but found 
 
 Microsoft.AspNetCore.Authentication.AuthenticationProperties
 {
-   AllowRefresh = <null>
-   ExpiresUtc = <null>
-   IsPersistent = False
-   IssuedUtc = <null>
-   Items = {empty}
-   Parameters = {empty}
-   RedirectUri = <null>
+    AllowRefresh = <null>, 
+    ExpiresUtc = <null>, 
+    IsPersistent = False, 
+    IssuedUtc = <null>, 
+    Items = {empty}, 
+    Parameters = {empty}, 
+    RedirectUri = <null>
 }.";
             return failureMessage;
         }

--- a/tests/FluentAssertions.AspNetCore.Mvc.Tests/ObjectResultAssertions_Tests.cs
+++ b/tests/FluentAssertions.AspNetCore.Mvc.Tests/ObjectResultAssertions_Tests.cs
@@ -262,7 +262,12 @@ namespace FluentAssertions.AspNetCore.Mvc.Tests
         public void WithValueEquivalentTo_GivenUnexpected_ShouldFail()
         {
             var result = new ObjectResult(WrongObject);
-            string failureMessage = @"Expected property actualValue.Value to be ""testValue"" with a length of 9 because it is 10, but ""wrongValue"" has a length of 10, differs near ""wro"" (index 0).
+#if DEBUG
+            var actualRef = "actualValue";
+#else
+            var actualRef = "root";
+#endif
+            string failureMessage = $@"Expected property {actualRef}.Value to be ""testValue"" with a length of 9 because it is 10, but ""wrongValue"" has a length of 10, differs near ""wro"" (index 0).
 
 With configuration:
 - Use declared types and members

--- a/tests/FluentAssertions.AspNetCore.Mvc.Tests/ObjectResultAssertions_Tests.cs
+++ b/tests/FluentAssertions.AspNetCore.Mvc.Tests/ObjectResultAssertions_Tests.cs
@@ -262,16 +262,18 @@ namespace FluentAssertions.AspNetCore.Mvc.Tests
         public void WithValueEquivalentTo_GivenUnexpected_ShouldFail()
         {
             var result = new ObjectResult(WrongObject);
-            string failureMessage = @"Expected member Value to be 
-""testValue"" with a length of 9 because it is 10, but 
-""wrongValue"" has a length of 10.
+            string failureMessage = @"Expected property actualValue.Value to be ""testValue"" with a length of 9 because it is 10, but ""wrongValue"" has a length of 10, differs near ""wro"" (index 0).
 
 With configuration:
 - Use declared types and members
 - Compare enums by value
+- Compare tuples by their properties
+- Compare anonymous types by their properties
+- Compare records by their members
 - Match member by name (or throw)
+- Be strict about the order of items in byte arrays
 - Without automatic conversion.
-- Be strict about the order of items in byte arrays";
+";
 
             Action a = () => result.Should().BeObjectResult().WithValueEquivalentTo(GoodObject, Reason, ReasonArgs);
 

--- a/tests/FluentAssertions.AspNetCore.Mvc.Tests/SignInResultAssertions_Tests.cs
+++ b/tests/FluentAssertions.AspNetCore.Mvc.Tests/SignInResultAssertions_Tests.cs
@@ -339,20 +339,16 @@ namespace FluentAssertions.AspNetCore.Mvc.Tests
         {
             var excpectedClaimsPrincipal = new ClaimsPrincipal();
             ActionResult result = new SignInResult(TestAuthenticationScheme, TestClaimsPrincipal);
-            var failureMessage = @"Expected SignInResult.Principal to be 
-
-System.Security.Claims.ClaimsPrincipal
+            var failureMessage = @"Expected SignInResult.Principal to be System.Security.Claims.ClaimsPrincipal
 {
-   Claims = {empty}
-   Identities = {empty}
-   Identity = <null>
-} because it is 10 but found 
-
-System.Security.Claims.ClaimsPrincipal
+    Claims = {empty}, 
+    Identities = {empty}, 
+    Identity = <null>
+} because it is 10 but found System.Security.Claims.ClaimsPrincipal
 {
-   Claims = {empty}
-   Identities = {empty}
-   Identity = <null>
+    Claims = {empty}, 
+    Identities = {empty}, 
+    Identity = <null>
 }.";
 
             Action a = () => result.Should().BeSignInResult().WithPrincipal(excpectedClaimsPrincipal, Reason, ReasonArgs);


### PR DESCRIPTION
In v6.0, class `FluentAssertions.Common.ObjectExtensions` was scoped internal. This was a breaking change to code that uses `IsSameOrEqualTo()` method. In a discussion [here](https://github.com/fluentassertions/fluentassertions/discussions/1644#discussioncomment-1181537) the author suggests to use object.Equals() instead.

This commit is incompatible with FluentAssertions v5.x due to breaking changes in FluentAssertions base classes. We probably need a new major version of FluentAssertions.AspNetCore.Mvc package.